### PR TITLE
Add Mastercard

### DIFF
--- a/data/index.js
+++ b/data/index.js
@@ -143,6 +143,11 @@ export const data = [
   { company_name: 'BASF', industry: 'Chemicals', stance: 'Taiwan' },
   // Financial Services
   {
+    company_name: 'Mastercard',
+    industry: 'Financial Services',
+    stance: 'Taiwan Region'
+  },
+  {
     company_name: 'Visa',
     industry: 'Financial Services',
     stance: 'Taiwan Region'


### PR DESCRIPTION
The initial call to action in the country selector on the US site calls to select your location. But they also have a subtext for missing countries and regions with "Don't see a country or region listed? Visit our global site."

When you visit the german site the initial call to action is to select your country.

What do you think how should we classify Mastercard?